### PR TITLE
Continue responding if multiple origins go offline

### DIFF
--- a/xrootd-redirector.cfg
+++ b/xrootd-redirector.cfg
@@ -51,3 +51,6 @@ xrd.tls /etc/grid-security/xrd/xrdcert.pem /etc/grid-security/xrd/xrdkey.pem
 xrd.tlsca noverify
 # Force TLS for the session
 xrootd.tls capable session
+
+# Continue responding if multiple origins go offline
+cms.delay servers 1%


### PR DESCRIPTION
By default, cmsd begins stalling if fewer than 80% of the high-water-mark of servers is currently subscribed